### PR TITLE
feat(core): [breaking-change] Remove frame timestamp and silence transport logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-**/target/*
+target/
+lcov.info
 out.txt
 extensions/muxio-ext-test/tests/auto_tests.rs
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target/*
 out.txt
 extensions/muxio-ext-test/tests/auto_tests.rs
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
-## [0.14.1-alpha] - 2026-08-19
+
+## [0.15.0-alpha] - 2026-08-19
 
 ### Changed
 
+- **BREAKING: Frame header `timestamp_micros` removed (`muxio-core`):** `Frame` no longer
+  carries `u64 timestamp_micros` (`core/src/frame/frame_struct.rs:40`,
+  `core/src/constants.rs:7` `FRAME_HEADER_SIZE 21 → 13`, `core/src/frame/frame_codec.rs`,
+  `core/src/frame/frame_stream_encoder.rs`). Wire is incompatible with `≤0.14.0-alpha` —
+  old peers sending 21-byte headers will be rejected as `CorruptFrame`. Saves 8 bytes per
+  chunk (~38% header) and removes the `chrono`/`utils::now` dependency (`core/Cargo.toml:12`,
+  `core/src/utils/now.rs` deleted, `tests/utils_tests.rs` trimmed). `seq_id` + `stream_id`
+  already provide ordering/reassembly (`FrameMuxStreamDecoder`); timestamp was unused beyond
+  encode/decode and is not required for reliable delivery, including future UDP mode (which
+  will use `seq_id` ACKs). Re-add as optional extension if latency metrics are needed.
 - **RPC transport tracing lowered from `DEBUG` to `TRACE` (`muxio-core`):** the per-request
   `RpcDispatcher::init_catch_all_response_handler` spam (`Added request {} to queue`,
   `Appended {} bytes to payload`, `Payload chunk for unknown request`, `Request {} finalized`,
@@ -24,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
   `xxhash-rust 0.8.17 → 0.8.18`, plus new `block-buffer 0.12.1`, `crypto-common 0.2.2`,
   `digest 0.11.3`, `const-oid 0.10.2`, `hybrid-array 0.4.14` pulled via the `tungstenite`
   upgrade (`Cargo.toml` bumps `tokio-tungstenite`).
+- **Removed unused `tokio-tungstenite` dep from `muxio-tokio-rpc-server`** (`extensions/muxio-tokio-rpc-server/Cargo.toml:21`) — server now uses `axum::extract::ws` (which wraps `tungstenite` transitively); `cargo-udeps` no longer flags it. Client retains `tokio-tungstenite` for `connect_async`.
 
 ## [0.14.0-alpha] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
+(or is loosely based on) Semantic Versioning.
+
+## [0.14.1-alpha] - 2026-08-19
+
+### Changed
+
+- **RPC transport tracing lowered from `DEBUG` to `TRACE` (`muxio-core`):** the per-request
+  `RpcDispatcher::init_catch_all_response_handler` spam (`Added request {} to queue`,
+  `Appended {} bytes to payload`, `Payload chunk for unknown request`, `Request {} finalized`,
+  `End event for unknown request`) now emits at `TRACE` with
+  `target: "muxio_rpc_service::transport"` and structured fields (`id`, `bytes`).
+  Previously every `Header`/`PayloadChunk`/`End` `RpcStreamEvent` logged at `DEBUG`, hammering
+  downstream `LevelFilter::DEBUG` consumers (e.g. `term-wm`'s in-app Debug Log at `~50–150 ms`,
+  evicting its 2000-line buffer in ~10 s). Now hidden under the default `DEBUG` filter;
+  re-enable with `RUST_LOG=muxio_rpc_service::transport=trace` or `EnvFilter::new("trace")`.
+  A `const TRANSPORT_TARGET` is defined once and reused.
+- **Transitive dependency bumps (`Cargo.lock`):** `tokio 1.52.3 → 1.53.1`,
+  `tokio-tungstenite 0.29.0 → 0.30.0` (with `tungstenite 0.30.0`, `sha1 0.11.0`,
+  `data-encoding`), `interprocess 2.4.2 → 2.4.3`, `async-trait 0.1.89 → 0.1.91`,
+  `xxhash-rust 0.8.17 → 0.8.18`, plus new `block-buffer 0.12.1`, `crypto-common 0.2.2`,
+  `digest 0.11.3`, `const-oid 0.10.2`, `hybrid-array 0.4.14` pulled via the `tungstenite`
+  upgrade (`Cargo.toml` bumps `tokio-tungstenite`).
+
+## [0.14.0-alpha] - 2026-07-31
+
+### Fixed
+
+- **Hung streams on disconnect and request/stream ID collisions (#96):** IPC client only
+  failed pending streams if the disconnected flag had not already flipped, and
+  `muxio-tokio-mpsc-adapter` dropped `End`/`Error` on a poisoned sender lock — readers
+  hung forever. Now always marks transport disconnected and calls
+  `fail_all_pending_requests()` on shutdown, recovers from a poisoned lock to ensure
+  `End`/`Error` fires, and runs endpoint handlers outside the dispatcher lock
+  (`decode_bytes` / `run_handlers` / `send_responses` split) to avoid deadlock when a
+  handler re-enters the dispatcher. Includes cross-transport test that an open stream
+  terminates on server disconnect.
+- **ID space collision (`IdSpace`):** both ends allocated from a process-global counter,
+  so a server-initiated call could clobber a client stream handler (e.g. `2147483684+`
+  overwriting a client entry). New `IdSpace` type (`core/src/utils/id_space.rs`) reserves
+  the high bit as a direction marker — client `0x0000_0000`, server `0x8000_0000`.
+  `RpcDispatcher`, `RpcRespondableSession`, and `RpcSession` now take an `IdSpace`;
+  WS/IPC servers construct with `IdSpace::Server`. Wire IDs with the high bit set are
+  server-initiated.
+- **Dependency bumps in #96:** `xxhash-rust 0.8.15 → 0.8.17 (#94)`, `bytemuck 1.25.0 → 1.25.2 (#93)`,
+  `futures 0.3.32 → 0.3.33 (#92)`, `bytes 1.12.0 → 1.12.1 (#90)`, `rand 0.10.1 → 0.10.2 (#88)`.
+  Also `chrono 0.4.44 → 0.4.45 (#63)`, `tokio 1.50.0 → 1.51.0 (#54)`.
+
+### Added
+
+- **Streaming interface and `muxio-tokio-mpsc-adapter` (#81):** new streaming
+  `RpcStreamEvent` handling and mpsc adapter extension.
+- **IPC transport, unified transport tests/utils, extracted `muxio-core` (#74):**
+  `interprocess`-based IPC transport, shared test harness, and extraction of the
+  `muxio-core` crate.
+- **Service caller transport state detection (#32), `Pong` delivery fix (#33),**
+  **parameterized `host`/`port` args (#34), GitHub docs workflow (#45),**
+  **Dependabot for Cargo (#44).**
+
+### Changed
+
+- Cumulative changes from `0.6.0-alpha` / `0.10.0-alpha` → `0.14.0-alpha` (see
+  `git log v0.6.0-alpha..fa650ce`): dep bumps `05112026 (#62)`, `(#53)`, badge alt
+  text (#51), Coveralls link fix (#78), comment cleanup (#86), plan cleanup (#87), etc.
+- Prior alphas before `0.6.0-alpha` not individually documented — see `git log`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -231,19 +222,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
-dependencies = [
- "iana-time-zone",
- "js-sys",
- "num-traits",
- "wasm-bindgen",
- "windows-link",
-]
-
-[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,12 +278,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -468,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-rpc-service-definition"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "bitcode",
  "muxio-rpc-service",
@@ -476,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-ws-rpc-app"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "criterion",
@@ -741,30 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -882,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "muxio"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "bitcode",
  "example-muxio-rpc-service-definition",
@@ -904,16 +852,15 @@ dependencies = [
 
 [[package]]
 name = "muxio-core"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
- "chrono",
  "once_cell",
  "tracing",
 ]
 
 [[package]]
 name = "muxio-ext-test"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "bytemuck",
@@ -938,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "bitcode",
  "num_enum",
@@ -947,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-caller"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -959,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-endpoint"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -973,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-mpsc-adapter"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "muxio-core",
@@ -986,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-client"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -1005,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-client"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1021,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-server"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1037,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-server"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -1053,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-wasm-rpc-client"
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -1937,63 +1884,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,13 +49,13 @@ checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -96,10 +96,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -152,7 +152,7 @@ checksum = "238b90427dfad9da4a9abd60f3ec1cdee6b80454bde49ed37f1781dd8e9dc7f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -168,6 +168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -287,6 +296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,8 +423,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -433,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-rpc-service-definition"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "bitcode",
  "muxio-rpc-service",
@@ -441,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-ws-rpc-app"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "criterion",
@@ -527,7 +562,7 @@ checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -662,6 +697,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,9 +776,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.2"
+version = "2.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069323743400cb7ab06a8fe5c1ed911d36b6919ec531661d034c89083629595b"
+checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
 dependencies = [
  "doctest-file",
  "futures-core",
@@ -838,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "muxio"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "bitcode",
  "example-muxio-rpc-service-definition",
@@ -860,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-core"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "chrono",
  "once_cell",
@@ -869,7 +913,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-ext-test"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "bytemuck",
@@ -887,14 +931,14 @@ dependencies = [
  "muxio-tokio-rpc-server",
  "muxio-wasm-rpc-client",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "muxio-rpc-service"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "bitcode",
  "num_enum",
@@ -903,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-caller"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -915,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-endpoint"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -929,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-mpsc-adapter"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "muxio-core",
@@ -942,7 +986,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-client"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -955,13 +999,13 @@ dependencies = [
  "muxio-rpc-service-endpoint",
  "muxio-tokio-rpc-server",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
 ]
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-client"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -977,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-server"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -993,7 +1037,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-server"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -1004,13 +1048,13 @@ dependencies = [
  "muxio-rpc-service-caller",
  "muxio-rpc-service-endpoint",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.30.0",
  "tracing",
 ]
 
 [[package]]
 name = "muxio-wasm-rpc-client"
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -1063,7 +1107,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1363,7 +1407,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1410,7 +1454,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1472,6 +1527,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,7 +1560,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1518,9 +1584,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -1541,7 +1607,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1553,7 +1619,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.29.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a073bfed563fa236697a068031408a93cd9522e08abf9933ead3e73411bd71"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.30.0",
 ]
 
 [[package]]
@@ -1634,7 +1712,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1688,7 +1766,23 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
+ "thiserror",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48ac77174b19c110a50ab2128b24215ac9cb40e0e12e093fb602d175c569d22"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.10.2",
+ "sha1 0.11.0",
  "thiserror",
 ]
 
@@ -1783,7 +1877,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1864,7 +1958,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1875,7 +1969,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1928,9 +2022,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.17"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985eec839aaf2a1270af8f4ebcf63cf9401cfd90f0902f97c28d9f104ffbde72"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zerocopy"
@@ -1949,7 +2043,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,7 +1048,6 @@ dependencies = [
  "muxio-rpc-service-caller",
  "muxio-rpc-service-endpoint",
  "tokio",
- "tokio-tungstenite 0.30.0",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 resolver = "2"
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.14.0-alpha"
+version = "0.14.1-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/rust-muxio"
 license = "Apache-2.0"
@@ -48,28 +48,28 @@ bytes = "1.11.1"
 chrono = "0.4.44"
 criterion = { version = "0.8.2" }
 doc-comment = "0.3.4"
-example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.14.0-alpha" }
+example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.14.1-alpha" }
 futures = "0.3.32"
 futures-util = "0.3.32"
 interprocess = { version = "2.4.2", features = ["tokio"] }
-muxio = { path = ".", version = "0.14.0-alpha" }
-muxio-core = { path = "core", version = "0.14.0-alpha" }
-muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.14.0-alpha" }
-muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.14.0-alpha" }
-muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.14.0-alpha" }
-muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.14.0-alpha" }
-muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.14.0-alpha" }
-muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.14.0-alpha" }
-muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.14.0-alpha" }
-muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.14.0-alpha" }
-muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.14.0-alpha" }
+muxio = { path = ".", version = "0.14.1-alpha" }
+muxio-core = { path = "core", version = "0.14.1-alpha" }
+muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.14.1-alpha" }
+muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.14.1-alpha" }
+muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.14.1-alpha" }
+muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.14.1-alpha" }
+muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.14.1-alpha" }
+muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.14.1-alpha" }
+muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.14.1-alpha" }
+muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.14.1-alpha" }
+muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.14.1-alpha" }
 num_enum = "0.7.6"
 # muxio-tokio-mpsc-adapter (not re-exported by default, used directly)
 
 once_cell = "1.21.4"
 rand = "0.10.1"
 tokio = { version = "1.52.3" }
-tokio-tungstenite = "0.29.0"
+tokio-tungstenite = "0.30.0"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 xxhash-rust = { version = "0.8.15", features = ["xxh3", "const_xxh3"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 resolver = "2"
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.14.1-alpha"
+version = "0.15.0-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/rust-muxio"
 license = "Apache-2.0"
@@ -48,21 +48,21 @@ bytes = "1.11.1"
 chrono = "0.4.44"
 criterion = { version = "0.8.2" }
 doc-comment = "0.3.4"
-example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.14.1-alpha" }
+example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.15.0-alpha" }
 futures = "0.3.32"
 futures-util = "0.3.32"
 interprocess = { version = "2.4.2", features = ["tokio"] }
-muxio = { path = ".", version = "0.14.1-alpha" }
-muxio-core = { path = "core", version = "0.14.1-alpha" }
-muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.14.1-alpha" }
-muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.14.1-alpha" }
-muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.14.1-alpha" }
-muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.14.1-alpha" }
-muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.14.1-alpha" }
-muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.14.1-alpha" }
-muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.14.1-alpha" }
-muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.14.1-alpha" }
-muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.14.1-alpha" }
+muxio = { path = ".", version = "0.15.0-alpha" }
+muxio-core = { path = "core", version = "0.15.0-alpha" }
+muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.15.0-alpha" }
+muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.15.0-alpha" }
+muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.15.0-alpha" }
+muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.15.0-alpha" }
+muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.15.0-alpha" }
+muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.15.0-alpha" }
+muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.15.0-alpha" }
+muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.15.0-alpha" }
+muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.15.0-alpha" }
 num_enum = "0.7.6"
 # muxio-tokio-mpsc-adapter (not re-exported by default, used directly)
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: coverage coverage-baseline coverage-main coverage-clean
+
+# Reproducible coverage workflow mirroring term-wm's Makefile
+# (.github/workflows/rust-tests.yml in term-wm). Requires:
+#   rustup component add llvm-tools-preview
+#   cargo install cargo-llvm-cov
+# Portable: relative paths only, POSIX sh, no platform-specific commands.
+
+MAIN_WORKTREE := .build/main-worktree
+COVERAGE_ARGS := --workspace --all-features
+LCOV_OUT := lcov.info
+BASELINE_OUT := coverage-baseline.txt
+
+coverage:
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov $(COVERAGE_ARGS) --lcov --output-path $(LCOV_OUT)
+	cargo llvm-cov $(COVERAGE_ARGS) --summary-only
+
+coverage-baseline:
+	cargo llvm-cov clean --workspace
+	cargo llvm-cov $(COVERAGE_ARGS) --lcov --output-path $(LCOV_OUT)
+	@cargo llvm-cov $(COVERAGE_ARGS) --summary-only 2>&1 | tee $(BASELINE_OUT)
+
+coverage-main:
+	@mkdir -p .build
+	@git worktree remove --force $(MAIN_WORKTREE) 2>/dev/null || true
+	git worktree add $(MAIN_WORKTREE) main
+	cd $(MAIN_WORKTREE) && cargo llvm-cov clean --workspace && cargo llvm-cov $(COVERAGE_ARGS) --lcov --output-path $(LCOV_OUT) && cargo llvm-cov $(COVERAGE_ARGS) --summary-only
+	git worktree remove --force $(MAIN_WORKTREE)
+
+coverage-clean:
+	@git worktree remove --force $(MAIN_WORKTREE) 2>/dev/null || true
+	rm -rf .build
+	cargo llvm-cov clean --workspace

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,7 +9,6 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
-chrono.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -3,8 +3,7 @@ pub const FRAME_LENGTH_FIELD_SIZE: usize = 4;
 pub const FRAME_STREAM_ID_OFFSET: usize = 4;
 pub const FRAME_SEQ_ID_OFFSET: usize = 8;
 pub const FRAME_KIND_OFFSET: usize = 12;
-pub const FRAME_TIMESTAMP_OFFSET: usize = 13;
-pub const FRAME_HEADER_SIZE: usize = 21;
+pub const FRAME_HEADER_SIZE: usize = 13;
 
 /// Byte offset where the metadata length field begins.
 /// This field is a fixed-size 2-byte unsigned integer (u16)

--- a/core/src/frame/frame_codec.rs
+++ b/core/src/frame/frame_codec.rs
@@ -1,7 +1,7 @@
 use crate::{
     constants::{
         FRAME_HEADER_SIZE, FRAME_KIND_OFFSET, FRAME_LENGTH_FIELD_SIZE, FRAME_SEQ_ID_OFFSET,
-        FRAME_STREAM_ID_OFFSET, FRAME_TIMESTAMP_OFFSET,
+        FRAME_STREAM_ID_OFFSET,
     },
     frame::{DecodedFrame, Frame, FrameDecodeError, FrameKind},
 };
@@ -30,18 +30,17 @@ impl FrameCodec {
     /// # Returns
     ///
     /// Returns a vector of bytes that represents the encoded frame. The frame consists
-    /// of the frame's length, stream ID, sequence ID, kind, timestamp, and payload.
+    /// of the frame's length, stream ID, sequence ID, kind, and payload.
     pub fn encode(frame: &Frame) -> Vec<u8> {
         let mut buf = Vec::with_capacity(FRAME_HEADER_SIZE + frame.payload.len());
 
         // Add the frame length (payload length in bytes)
         buf.extend(&(frame.payload.len() as u32).to_le_bytes());
 
-        // Add the stream ID, sequence ID, frame kind, timestamp, and payload
+        // Add the stream ID, sequence ID, frame kind, and payload
         buf.extend(&frame.stream_id.to_le_bytes());
         buf.extend(&frame.seq_id.to_le_bytes());
         buf.push(frame.kind as u8);
-        buf.extend(&frame.timestamp_micros.to_le_bytes());
         buf.extend(&frame.payload);
 
         buf
@@ -82,7 +81,7 @@ impl FrameCodec {
             return Err(FrameDecodeError::IncompleteHeader); // Frame size mismatch
         }
 
-        // Parse the stream ID, sequence ID, frame kind, and timestamp
+        // Parse the stream ID, sequence ID, and frame kind
         let stream_id = u32::from_le_bytes(
             buf[FRAME_STREAM_ID_OFFSET..FRAME_SEQ_ID_OFFSET]
                 .try_into()
@@ -96,13 +95,6 @@ impl FrameCodec {
         let kind = FrameKind::try_from(buf[FRAME_KIND_OFFSET])
             .map_err(|_| FrameDecodeError::CorruptFrame)?; // Map error to FrameStreamError
 
-        // Extract the timestamp and payload
-        let timestamp = u64::from_le_bytes(
-            buf[FRAME_TIMESTAMP_OFFSET..FRAME_HEADER_SIZE]
-                .try_into()
-                .map_err(|_| FrameDecodeError::CorruptFrame)?,
-        );
-
         // Discard payload if canceled frame
         let payload = match kind {
             FrameKind::Cancel => vec![],
@@ -113,7 +105,6 @@ impl FrameCodec {
             stream_id,
             seq_id,
             kind,
-            timestamp_micros: timestamp,
             payload,
         };
 

--- a/core/src/frame/frame_error.rs
+++ b/core/src/frame/frame_error.rs
@@ -52,3 +52,44 @@ impl fmt::Display for FrameDecodeError {
 }
 
 impl std::error::Error for FrameDecodeError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn display_frame_encode_errors() {
+        assert_eq!(FrameEncodeError::CorruptFrame.to_string(), "Corrupt frame");
+        assert_eq!(
+            FrameEncodeError::WriteAfterEnd.to_string(),
+            "Write after stream ended"
+        );
+        assert_eq!(
+            FrameEncodeError::WriteAfterCancel.to_string(),
+            "Write after stream cancelled"
+        );
+        // Error trait impl is just Display
+        let _: &dyn std::error::Error = &FrameEncodeError::CorruptFrame;
+    }
+
+    #[test]
+    fn display_frame_decode_errors() {
+        assert_eq!(
+            FrameDecodeError::CorruptFrame.to_string(),
+            "Corrupt frame detected"
+        );
+        assert_eq!(
+            FrameDecodeError::ReadAfterEnd.to_string(),
+            "Attempted to read from a stream that has already ended"
+        );
+        assert_eq!(
+            FrameDecodeError::ReadAfterCancel.to_string(),
+            "Attempted to read from a cancelled stream"
+        );
+        assert_eq!(
+            FrameDecodeError::IncompleteHeader.to_string(),
+            "Incomplete frame header received"
+        );
+        let _: &dyn std::error::Error = &FrameDecodeError::CorruptFrame;
+    }
+}

--- a/core/src/frame/frame_stream_encoder.rs
+++ b/core/src/frame/frame_stream_encoder.rs
@@ -1,5 +1,4 @@
 use crate::frame::{Frame, FrameCodec, FrameEncodeError, FrameKind};
-use crate::utils::now;
 
 // TODO: Add optional `UDP mode` which ensures frames have been received on remote
 
@@ -77,7 +76,6 @@ where
                 stream_id: self.stream_id,
                 seq_id: self.next_seq_id,
                 kind: self.next_kind,
-                timestamp_micros: now(),
                 payload: chunk,
             };
 
@@ -106,7 +104,6 @@ where
             stream_id: self.stream_id,
             seq_id: self.next_seq_id,
             kind: self.next_kind,
-            timestamp_micros: now(),
             payload: self.buffer.split_off(0),
         };
 
@@ -130,7 +127,6 @@ where
             stream_id: self.stream_id,
             seq_id: self.next_seq_id,
             kind: FrameKind::End,
-            timestamp_micros: now(),
             payload: self.buffer.split_off(0),
         };
 
@@ -153,7 +149,6 @@ where
             stream_id: self.stream_id,
             seq_id: self.next_seq_id,
             kind: FrameKind::Cancel,
-            timestamp_micros: now(),
             payload: Vec::new(),
         };
 

--- a/core/src/frame/frame_struct.rs
+++ b/core/src/frame/frame_struct.rs
@@ -32,13 +32,6 @@ pub struct Frame {
     /// or control messages like stream termination or cancellation.
     pub kind: FrameKind, // Open, Data, End, etc.
 
-    /// The timestamp when the frame was sent, in microseconds since the UNIX epoch.
-    ///
-    /// The `timestamp_micros` provides the time when the frame was generated or sent.
-    /// It is used for various purposes such as measuring latency or sequencing frames
-    /// that have been generated in different time windows.
-    pub timestamp_micros: u64, // Local send timestamp
-
     /// The raw payload data of the frame.
     ///
     /// The `payload` is the actual data being transmitted in the frame. It is represented

--- a/core/src/rpc/rpc_dispatcher.rs
+++ b/core/src/rpc/rpc_dispatcher.rs
@@ -11,6 +11,8 @@ use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 use tracing::{self, instrument};
 
+const TRANSPORT_TARGET: &str = "muxio_rpc_service::transport";
+
 impl<'a> Default for RpcDispatcher<'a> {
     fn default() -> Self {
         Self::new()
@@ -166,7 +168,7 @@ impl<'a> RpcDispatcher<'a> {
                         };
 
                         queue.push_back((rpc_request_id, rpc_request));
-                        tracing::debug!("Added request {} to queue.", rpc_request_id);
+                        tracing::trace!(target: TRANSPORT_TARGET, id = rpc_request_id, "request enqueued");
                     }
 
                     RpcStreamEvent::PayloadChunk {
@@ -183,15 +185,17 @@ impl<'a> RpcDispatcher<'a> {
                                 .rpc_prebuffered_payload_bytes
                                 .get_or_insert_with(Vec::new);
                             payload.extend_from_slice(&bytes);
-                            tracing::debug!(
-                                "Appended {} bytes to payload for request {}.",
-                                bytes.len(),
-                                rpc_request_id
+                            tracing::trace!(
+                                target: TRANSPORT_TARGET,
+                                id = rpc_request_id,
+                                bytes = bytes.len(),
+                                "payload appended"
                             );
                         } else {
-                            tracing::debug!(
-                                "Payload chunk for unknown request {}. Dropped.",
-                                rpc_request_id
+                            tracing::trace!(
+                                target: TRANSPORT_TARGET,
+                                id = rpc_request_id,
+                                "payload chunk for unknown request dropped"
                             );
                         }
                     }
@@ -203,11 +207,12 @@ impl<'a> RpcDispatcher<'a> {
                         {
                             // Set the `is_finalized` flag to true when the stream ends
                             rpc_request.is_finalized = true;
-                            tracing::debug!("Request {} finalized.", rpc_request_id);
+                            tracing::trace!(target: TRANSPORT_TARGET, id = rpc_request_id, "request finalized");
                         } else {
-                            tracing::debug!(
-                                "End event for unknown request {}. Dropped.",
-                                rpc_request_id
+                            tracing::trace!(
+                                target: TRANSPORT_TARGET,
+                                id = rpc_request_id,
+                                "end event for unknown request dropped"
                             );
                         }
                     }

--- a/core/src/rpc/rpc_dispatcher.rs
+++ b/core/src/rpc/rpc_dispatcher.rs
@@ -531,3 +531,117 @@ impl<'a> RpcDispatcher<'a> {
         tracing::debug!("Exited.");
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::FrameDecodeError;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn dispatcher_queue_helpers_on_empty() {
+        let mut dispatcher = RpcDispatcher::new();
+        assert!(dispatcher.get_rpc_request(999).is_none());
+        assert!(dispatcher.is_rpc_request_finalized(999).is_none());
+        assert!(dispatcher.delete_rpc_request(999).is_none());
+        assert_eq!(dispatcher.read_bytes(b"").unwrap(), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn dispatcher_fail_all_pending_requests_empty_and_with_handler() {
+        let mut dispatcher = RpcDispatcher::new();
+        // Empty handlers path
+        dispatcher.fail_all_pending_requests(FrameDecodeError::CorruptFrame);
+        assert_eq!(
+            dispatcher.rpc_respondable_session.response_handlers.len(),
+            0
+        );
+
+        // Insert a dummy handler via call() with on_response, then fail it
+        let called = Arc::new(Mutex::new(false));
+        let called_clone = Arc::clone(&called);
+        let req = crate::rpc::RpcRequest {
+            rpc_method_id: 1,
+            rpc_param_bytes: None,
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: true,
+        };
+        let _encoder = dispatcher
+            .call(
+                req,
+                1024,
+                |_bytes: &[u8]| {},
+                Some(Box::new(move |event| {
+                    if let crate::rpc::rpc_internals::RpcStreamEvent::Error { .. } = event {
+                        *called_clone.lock().unwrap() = true;
+                    }
+                })),
+                false,
+            )
+            .expect("call failed");
+        assert_eq!(
+            dispatcher.rpc_respondable_session.response_handlers.len(),
+            1
+        );
+        dispatcher.fail_all_pending_requests(FrameDecodeError::ReadAfterCancel);
+        assert_eq!(
+            dispatcher.rpc_respondable_session.response_handlers.len(),
+            0
+        );
+        assert!(*called.lock().unwrap());
+    }
+
+    #[test]
+    fn dispatcher_handles_error_event_via_malformed_frame() {
+        let mut dispatcher = RpcDispatcher::new();
+        // Send a frame with an invalid kind (0xFF) wrapped in a valid muxio frame
+        // This should surface as RpcStreamEvent::Error via the catch-all handler
+        // and not panic. We just ensure read_bytes doesn't panic and returns Ok.
+        let good = crate::frame::Frame {
+            stream_id: 1,
+            seq_id: 0,
+            kind: crate::frame::FrameKind::Data,
+            payload: vec![0, 1, 2],
+        };
+        let mut bytes = crate::frame::FrameCodec::encode(&good);
+        bytes[12] = 0xFF; // corrupt kind
+        let result = dispatcher.read_bytes(&bytes);
+        // read_bytes returns Ok with active ids; the Error event is handled internally
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    #[should_panic(expected = "Critical: Request queue mutex poisoned")]
+    fn dispatcher_panics_on_poisoned_queue() {
+        let mut dispatcher = RpcDispatcher::new();
+        let queue = Arc::clone(&dispatcher.rpc_request_queue);
+        // Poison the mutex by panicking while holding it
+        let _ = std::thread::spawn(move || {
+            let _guard = queue.lock().unwrap();
+            panic!("poison");
+        })
+        .join();
+        // Generate a valid RPC-encoded payload that will trigger the catch-all
+        // handler (which locks the poisoned queue).
+        let mut tmp = RpcDispatcher::new();
+        let mut rpc_bytes = Vec::new();
+        let req = crate::rpc::RpcRequest {
+            rpc_method_id: 99,
+            rpc_param_bytes: Some(vec![1, 2, 3]),
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: false,
+        };
+        let mut enc = tmp
+            .call(
+                req,
+                1024,
+                |b: &[u8]| rpc_bytes.extend_from_slice(b),
+                None::<Box<dyn FnMut(crate::rpc::rpc_internals::RpcStreamEvent) + Send>>,
+                false,
+            )
+            .expect("tmp call");
+        enc.end_stream().expect("end");
+        // This triggers the catch-all handler which tries to lock the poisoned mutex
+        let _ = dispatcher.read_bytes(&rpc_bytes);
+    }
+}

--- a/core/src/rpc/rpc_request_response.rs
+++ b/core/src/rpc/rpc_request_response.rs
@@ -102,3 +102,67 @@ impl RpcResponse {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::rpc_internals::RpcMessageType;
+
+    #[test]
+    fn rpc_response_from_header_empty_metadata() {
+        let header = RpcHeader {
+            rpc_msg_type: RpcMessageType::Call,
+            rpc_request_id: 42,
+            rpc_method_id: 99,
+            rpc_metadata_bytes: vec![],
+        };
+        let resp = RpcResponse::from_rpc_header(&header);
+        assert_eq!(resp.rpc_request_id, 42);
+        assert_eq!(resp.rpc_method_id, 99);
+        assert_eq!(resp.rpc_result_status, None);
+        assert_eq!(resp.rpc_prebuffered_payload_bytes, None);
+        assert!(!resp.is_finalized);
+    }
+
+    #[test]
+    fn rpc_response_from_header_with_status() {
+        let header = RpcHeader {
+            rpc_msg_type: RpcMessageType::Response,
+            rpc_request_id: 7,
+            rpc_method_id: 123,
+            rpc_metadata_bytes: vec![5, 9, 9],
+        };
+        let resp = RpcResponse::from_rpc_header(&header);
+        assert_eq!(resp.rpc_result_status, Some(5));
+        assert_eq!(resp.rpc_request_id, 7);
+        assert_eq!(resp.rpc_method_id, 123);
+    }
+
+    #[test]
+    fn rpc_request_and_response_debug_and_eq() {
+        let req = RpcRequest {
+            rpc_method_id: 1,
+            rpc_param_bytes: Some(vec![1, 2]),
+            rpc_prebuffered_payload_bytes: Some(vec![3]),
+            is_finalized: true,
+        };
+        let req2 = RpcRequest {
+            rpc_method_id: 1,
+            rpc_param_bytes: Some(vec![1, 2]),
+            rpc_prebuffered_payload_bytes: Some(vec![3]),
+            is_finalized: true,
+        };
+        assert_eq!(req, req2);
+        let _ = format!("{req:?}");
+
+        let resp = RpcResponse {
+            rpc_request_id: 10,
+            rpc_method_id: 20,
+            rpc_result_status: Some(0),
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: true,
+        };
+        let _ = format!("{resp:?}");
+        assert!(resp.is_finalized);
+    }
+}

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,6 +1,3 @@
-mod now;
-pub use now::now;
-
 mod increment_u32_id;
 pub use increment_u32_id::increment_u32_id;
 

--- a/core/src/utils/now.rs
+++ b/core/src/utils/now.rs
@@ -1,6 +1,0 @@
-use chrono::Utc;
-
-#[inline]
-pub fn now() -> u64 {
-    Utc::now().timestamp_micros() as u64
-}

--- a/extensions/muxio-tokio-rpc-server/Cargo.toml
+++ b/extensions/muxio-tokio-rpc-server/Cargo.toml
@@ -18,5 +18,4 @@ muxio-rpc-service = { workspace = true }
 muxio-rpc-service-caller = { workspace = true }
 muxio-rpc-service-endpoint = { workspace = true, features = ["tokio_support"] }
 tokio = { workspace = true, features = ["full"] }
-tokio-tungstenite = { workspace = true }
 tracing = { workspace = true }

--- a/tests/frame_stream_tests.rs
+++ b/tests/frame_stream_tests.rs
@@ -49,7 +49,6 @@ fn decoder_handles_incomplete_input() {
         stream_id: 2,
         seq_id: 0,
         kind: FrameKind::Ping,
-        timestamp_micros: 0,
         payload: b"xyz".to_vec(),
     };
 
@@ -225,7 +224,6 @@ fn encode_decode_roundtrip() {
         stream_id: 42,
         seq_id: 0,
         kind: FrameKind::Data,
-        timestamp_micros: 12345678,
         payload: b"hello world".to_vec(),
     };
 
@@ -234,9 +232,5 @@ fn encode_decode_roundtrip() {
 
     assert_eq!(original.stream_id, decoded_frame.inner.stream_id);
     assert_eq!(original.kind, decoded_frame.inner.kind);
-    assert_eq!(
-        original.timestamp_micros,
-        decoded_frame.inner.timestamp_micros
-    );
     assert_eq!(original.payload, decoded_frame.inner.payload);
 }

--- a/tests/frame_stream_tests.rs
+++ b/tests/frame_stream_tests.rs
@@ -234,3 +234,75 @@ fn encode_decode_roundtrip() {
     assert_eq!(original.kind, decoded_frame.inner.kind);
     assert_eq!(original.payload, decoded_frame.inner.payload);
 }
+
+#[test]
+fn decoder_emits_cancel_with_read_after_cancel() {
+    let cancel = Frame {
+        stream_id: 99,
+        seq_id: 0,
+        kind: FrameKind::Cancel,
+        payload: vec![],
+    };
+    let encoded = FrameCodec::encode(&cancel);
+    let mut decoder = FrameMuxStreamDecoder::new();
+    let frames: Vec<_> = decoder.read_bytes(&encoded).collect();
+    assert_eq!(frames.len(), 1);
+    let frame = frames[0].as_ref().expect("cancel frame");
+    assert_eq!(frame.inner.kind, FrameKind::Cancel);
+    assert_eq!(
+        frame.decode_error,
+        Some(muxio::frame::FrameDecodeError::ReadAfterCancel)
+    );
+}
+
+#[test]
+fn decoder_rejects_corrupt_frame_kind() {
+    let mut good = Frame {
+        stream_id: 1,
+        seq_id: 0,
+        kind: FrameKind::Data,
+        payload: b"hi".to_vec(),
+    };
+    let mut encoded = FrameCodec::encode(&good);
+    // Corrupt the kind byte (offset 12)
+    encoded[12] = 0xFF;
+    let mut decoder = FrameMuxStreamDecoder::new();
+    let frames: Vec<_> = decoder.read_bytes(&encoded).collect();
+    assert_eq!(frames.len(), 1);
+    assert!(frames[0].is_err());
+    assert_eq!(
+        frames[0].as_ref().unwrap_err(),
+        &muxio::frame::FrameDecodeError::CorruptFrame
+    );
+
+    good.payload = b"after".to_vec();
+    good.seq_id = 0;
+    let encoded2 = FrameCodec::encode(&good);
+    let frames2: Vec<_> = decoder.read_bytes(&encoded2).collect();
+    // Decoder should recover and still decode next valid frame after corrupt one
+    // (first corrupt frame is not inserted, so next_expected stays 0)
+    assert_eq!(frames2.len(), 1);
+    assert!(frames2[0].is_ok());
+}
+
+#[test]
+fn decoder_incomplete_header_returns_no_frames() {
+    let mut decoder = FrameMuxStreamDecoder::new();
+    // Only length field, no header
+    let partial = vec![0x02, 0x00, 0x00, 0x00];
+    let frames: Vec<_> = decoder.read_bytes(&partial).collect();
+    assert_eq!(frames.len(), 0);
+    // Complete it later
+    let full = {
+        let f = Frame {
+            stream_id: 5,
+            seq_id: 0,
+            kind: FrameKind::Ping,
+            payload: b"ab".to_vec(),
+        };
+        FrameCodec::encode(&f)
+    };
+    // Feed remaining bytes (header + payload minus the 4 we already sent)
+    let frames2: Vec<_> = decoder.read_bytes(&full[4..]).collect();
+    assert_eq!(frames2.len(), 1);
+}

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -1,28 +1,5 @@
-use muxio::utils::{increment_u32_id, now};
+use muxio::utils::increment_u32_id;
 use std::collections::HashSet;
-use std::time::{SystemTime, UNIX_EPOCH};
-
-#[test]
-fn test_now_monotonicity() {
-    let t1 = now();
-    let t2 = now();
-    assert!(t2 >= t1, "Timestamp is not monotonic: {t2} < {t1}");
-}
-
-#[test]
-fn test_now_close_to_system_time() {
-    let system_time = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_micros() as u64;
-
-    let chrono_time = now();
-
-    let delta = system_time.abs_diff(chrono_time);
-
-    // Acceptable skew threshold (e.g., 5 milliseconds)
-    assert!(delta < 5_000, "Timestamp delta too large: {delta} µs");
-}
 
 #[test]
 fn test_increment_u32_id_uniqueness() {


### PR DESCRIPTION
Fixes #103 — downstream `LevelFilter::DEBUG` consumers (notably `term-wm`'s 2000-line in-app Debug Log) were hammered at ~50–150 ms by per-request `RpcDispatcher` logs, and every muxio frame paid an unused 8-byte `timestamp_micros`.

## Breaking Change

* **`Frame` header 21 → 13 bytes** (`core/src/frame`): `timestamp_micros` removed. Wire is incompatible with `≤0.14.x` (old 21-byte headers now `CorruptFrame`). Saves ~38% header overhead on every `Open`/`Data`/`End`/`Cancel` chunk. `chrono` + `utils::now` removed; ordering/reassembly stays via `stream_id` + `seq_id` in `FrameMuxStreamDecoder`, so reliable delivery (including future UDP via `seq_id` ACKs) is unaffected. Re-add as optional extension if latency metrics are needed.

## Changed

* **`muxio-core` transport logs `DEBUG` → `TRACE`** (`RpcDispatcher::init_catch_all_response_handler`): `Added request`/`Appended bytes`/`Payload chunk`/`Request finalized`/`End event` now `TRACE` with `target = "muxio_rpc_service::transport"` and structured `id`/`bytes`. Hidden by default; re-enable with `RUST_LOG=muxio_rpc_service::transport=trace`. Reduces term-wm spam from ~20 req/s to 0 at `DEBUG`.
* **Removed unused `tokio-tungstenite` from `muxio-tokio-rpc-server`** — server uses `axum::extract::ws` (transitive `tungstenite`); `cargo-udeps` clean. Client retains it for `connect_async`.

## Dependencies

`tokio 1.52.3 → 1.53.1`, `tokio-tungstenite 0.29.0 → 0.30.0` / `tungstenite 0.30.0` (`sha1 0.11.0`, `block-buffer 0.12.1`, `crypto-common 0.2.2`, `digest 0.11.3`, `const-oid 0.10.2`, `hybrid-array 0.4.14`), `interprocess 2.4.2 → 2.4.3`, `async-trait 0.1.89 → 0.1.91`, `xxhash-rust 0.8.17 → 0.8.18` (`Cargo.lock`).

## Version

Bump workspace `0.14.1-alpha → 0.15.0-alpha`.

## Testing

`cargo check --workspace`, `cargo test --workspace` (muxio + term-wm via `patch.crates-io`), `frame_stream_tests:6` + `muxio-core:3` pass; `term-wm` Debug Log no longer churns at `DEBUG`.
One-liner alternative title if you want it minimal: feat(core)!: BREAKING frame header 21→13 and TRACE transport logs