### PR TITLE
feat(core): Frame `Transport` decode error variant 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ lcov.info
 out.txt
 extensions/muxio-ext-test/tests/auto_tests.rs
 .DS_Store
+*.patch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
-## [Unreleased]
+## [0.16.0-alpha] - 2026-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 - **Panic-aware server per-connection tasks:** `handle_connection` now retains `writer_handle` and `reader_handle`, checks `JoinError::is_panic()` and logs with `conn_id` instead of silently discarding via `select!` drop, and aborts the peer task.
 - **Write queue depth visibility:** defined `WRITE_QUEUE_WARN_THRESHOLD` and `SERVER_WRITE_QUEUE_WARN_THRESHOLD` with a client-side atomic counter and `warn!` when the threshold is exceeded; full backpressure redesign remains deferred.
+- **Dependency bumps (`Cargo.lock`):** `futures 0.3.33 → 0.3.34` (#105), `async-trait 0.1.91 → 0.1.92` (#104) — patch bumps via Dependabot (`futures 0.3.34` upgrades `futures-channel`, `futures-core`, `futures-executor`, `futures-io`, `futures-sink`, `futures-task`, `futures-util`, `futures-macro` with `syn 2.0.118 → 3.0.3`).
 
 ## [0.15.0-alpha] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/) and this project adheres to
 (or is loosely based on) Semantic Versioning.
 
+## [Unreleased]
+
+### Added
+
+- **Frame `Transport` decode error variant (`muxio-core`):** new `FrameDecodeError::Transport(String)` carries the real `std::io::Error` display for transport failures so `fail_all_pending_requests` can surface `ConnectionReset`, `BrokenPipe`, or `UnexpectedEof` instead of a static `ReadAfterCancel`.
+
+### Fixed
+
+- **IPC client/server transport error propagation:** client read loop now distinguishes `Ok(0)` (synthesized unexpected EOF) from `Err(e)` (logs `warn!` and stores the error) instead of swallowing via `ok()?`, server read loop does the same, and both shutdown paths thread the concrete error into `fail_all_pending_requests` so pending oneshots receive the root cause.
+- **Prebuffering flags leak:** `prebuffering_flags` entries were inserted per outbound call and never removed; now cleared on `End`/`Error` and via `clear_all_prebuffering` in `fail_all`.
+- **Inbound request queue leak:** `rpc_request_queue` entries for errored or non-finalized streams lingered; `fail_all_pending_requests` now drains the queue so a dead connection does not leak state.
+
+### Changed
+
+- **Panic-aware server per-connection tasks:** `handle_connection` now retains `writer_handle` and `reader_handle`, checks `JoinError::is_panic()` and logs with `conn_id` instead of silently discarding via `select!` drop, and aborts the peer task.
+- **Write queue depth visibility:** defined `WRITE_QUEUE_WARN_THRESHOLD` and `SERVER_WRITE_QUEUE_WARN_THRESHOLD` with a client-side atomic counter and `warn!` when the threshold is exceeded; full backpressure redesign remains deferred.
 
 ## [0.15.0-alpha] - 2026-08-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -505,15 +505,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -522,38 +522,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-rpc-service-definition"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "bitcode",
  "muxio-rpc-service",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "example-muxio-ws-rpc-app"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "criterion",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "muxio"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "bitcode",
  "example-muxio-rpc-service-definition",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-core"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "once_cell",
  "tracing",
@@ -860,7 +860,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-ext-test"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "bytemuck",
@@ -885,7 +885,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "bitcode",
  "num_enum",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-caller"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "futures",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-rpc-service-endpoint"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -920,7 +920,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-mpsc-adapter"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "muxio-core",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-client"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-client"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -968,7 +968,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-ipc-server"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-tokio-rpc-server"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "axum",
@@ -1000,7 +1000,7 @@ dependencies = [
 
 [[package]]
 name = "muxio-wasm-rpc-client"
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 dependencies = [
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 resolver = "2"
 [workspace.package]
 authors = ["Jeremy Harris <jeremy.harris@zenosmosis.com>"]
-version = "0.15.0-alpha"
+version = "0.16.0-alpha"
 edition = "2024"
 repository = "https://github.com/jzombie/rust-muxio"
 license = "Apache-2.0"
@@ -48,21 +48,21 @@ bytes = "1.11.1"
 chrono = "0.4.44"
 criterion = { version = "0.8.2" }
 doc-comment = "0.3.4"
-example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.15.0-alpha" }
+example-muxio-rpc-service-definition = { path = "examples/example-muxio-rpc-service-definition", version = "0.16.0-alpha" }
 futures = "0.3.32"
 futures-util = "0.3.32"
 interprocess = { version = "2.4.2", features = ["tokio"] }
-muxio = { path = ".", version = "0.15.0-alpha" }
-muxio-core = { path = "core", version = "0.15.0-alpha" }
-muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.15.0-alpha" }
-muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.15.0-alpha" }
-muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.15.0-alpha" }
-muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.15.0-alpha" }
-muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.15.0-alpha" }
-muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.15.0-alpha" }
-muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.15.0-alpha" }
-muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.15.0-alpha" }
-muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.15.0-alpha" }
+muxio = { path = ".", version = "0.16.0-alpha" }
+muxio-core = { path = "core", version = "0.16.0-alpha" }
+muxio-rpc-service = { path = "extensions/muxio-rpc-service", version = "0.16.0-alpha" }
+muxio-rpc-service-caller = { path = "extensions/muxio-rpc-service-caller", version = "0.16.0-alpha" }
+muxio-rpc-service-endpoint = { path = "extensions/muxio-rpc-service-endpoint", version = "0.16.0-alpha" }
+muxio-tokio-mpsc-adapter = { path = "extensions/muxio-tokio-mpsc-adapter", version = "0.16.0-alpha" }
+muxio-tokio-rpc-client = { path = "extensions/muxio-tokio-rpc-client", version = "0.16.0-alpha" }
+muxio-tokio-rpc-ipc-client = { path = "extensions/muxio-tokio-rpc-ipc-client", version = "0.16.0-alpha" }
+muxio-tokio-rpc-ipc-server = { path = "extensions/muxio-tokio-rpc-ipc-server", version = "0.16.0-alpha" }
+muxio-tokio-rpc-server = { path = "extensions/muxio-tokio-rpc-server", version = "0.16.0-alpha" }
+muxio-wasm-rpc-client = { path = "extensions/muxio-wasm-rpc-client", version = "0.16.0-alpha" }
 num_enum = "0.7.6"
 # muxio-tokio-mpsc-adapter (not re-exported by default, used directly)
 

--- a/core/src/frame/frame_error.rs
+++ b/core/src/frame/frame_error.rs
@@ -34,6 +34,12 @@ pub enum FrameDecodeError {
     ReadAfterCancel,
 
     IncompleteHeader,
+
+    /// Transport-level I/O error carrying the real `std::io::Error` display.
+    /// Used by `fail_all_pending_requests` to surface the root cause
+    /// (e.g. `ConnectionReset`, `BrokenPipe`, `UnexpectedEof`) instead of a
+    /// static `ReadAfterCancel`.
+    Transport(String),
 }
 
 impl fmt::Display for FrameDecodeError {
@@ -47,6 +53,7 @@ impl fmt::Display for FrameDecodeError {
                 write!(f, "Attempted to read from a cancelled stream")
             }
             FrameDecodeError::IncompleteHeader => write!(f, "Incomplete frame header received"),
+            FrameDecodeError::Transport(msg) => write!(f, "Transport error: {msg}"),
         }
     }
 }
@@ -91,5 +98,29 @@ mod tests {
             "Incomplete frame header received"
         );
         let _: &dyn std::error::Error = &FrameDecodeError::CorruptFrame;
+    }
+
+    #[test]
+    fn display_frame_decode_transport_error() {
+        let err = FrameDecodeError::Transport("ConnectionReset".to_string());
+        assert_eq!(err.to_string(), "Transport error: ConnectionReset");
+        let _: &dyn std::error::Error = &err;
+
+        let empty = FrameDecodeError::Transport(String::new());
+        assert_eq!(empty.to_string(), "Transport error: ");
+        let _: &dyn std::error::Error = &empty;
+
+        let eof = FrameDecodeError::Transport("unexpected EOF (connection closed)".to_string());
+        assert!(eof.to_string().contains("unexpected EOF"));
+        let _: &dyn std::error::Error = &eof;
+
+        assert_eq!(
+            FrameDecodeError::Transport("a".to_string()),
+            FrameDecodeError::Transport("a".to_string())
+        );
+        assert_ne!(
+            FrameDecodeError::Transport("a".to_string()),
+            FrameDecodeError::CorruptFrame
+        );
     }
 }

--- a/core/src/rpc/rpc_dispatcher.rs
+++ b/core/src/rpc/rpc_dispatcher.rs
@@ -37,7 +37,7 @@ impl<'a> Default for RpcDispatcher<'a> {
 /// IMPORTANT: A unique dispatcher should be used per-client.
 pub struct RpcDispatcher<'a> {
     /// Core session responsible for managing stream lifecycles and handlers.
-    rpc_respondable_session: RpcRespondableSession<'a>,
+    pub(crate) rpc_respondable_session: RpcRespondableSession<'a>,
 
     /// Direction of this connection end; request ids are allocated from the
     /// matching half of the id space so client and server can never collide.
@@ -510,6 +510,13 @@ impl<'a> RpcDispatcher<'a> {
 
         // Take ownership of the handlers, leaving the map empty.
         let handlers = std::mem::take(&mut self.rpc_respondable_session.response_handlers);
+        // Clear prebuffering state and any pending inbound request queue
+        // entries that would otherwise linger for the dispatcher's lifetime
+        // (see TODOs at `rpc_request_queue` push sites).
+        self.rpc_respondable_session.clear_all_prebuffering();
+        if let Ok(mut queue) = self.rpc_request_queue.lock() {
+            queue.clear();
+        }
 
         tracing::debug!("Taken {} handlers.", handlers.len());
 
@@ -643,5 +650,94 @@ mod tests {
         enc.end_stream().expect("end");
         // This triggers the catch-all handler which tries to lock the poisoned mutex
         let _ = dispatcher.read_bytes(&rpc_bytes);
+    }
+
+    #[test]
+    fn dispatcher_fail_all_propagates_transport_error() {
+        for (msg, should_contain) in [
+            ("ConnectionReset", "ConnectionReset"),
+            ("BrokenPipe", "BrokenPipe"),
+            ("unexpected EOF (connection closed)", "unexpected EOF"),
+        ] {
+            let mut dispatcher = RpcDispatcher::new();
+            let received = Arc::new(Mutex::new(None::<FrameDecodeError>));
+            let received_clone = Arc::clone(&received);
+            let req = crate::rpc::RpcRequest {
+                rpc_method_id: 42,
+                rpc_param_bytes: None,
+                rpc_prebuffered_payload_bytes: None,
+                is_finalized: true,
+            };
+            let _encoder = dispatcher
+                .call(
+                    req,
+                    1024,
+                    |_: &[u8]| {},
+                    Some(Box::new(move |event| {
+                        if let crate::rpc::rpc_internals::RpcStreamEvent::Error {
+                            frame_decode_error,
+                            ..
+                        } = event
+                        {
+                            *received_clone.lock().unwrap() = Some(frame_decode_error.clone());
+                        }
+                    })),
+                    false,
+                )
+                .expect("call failed");
+            let err = FrameDecodeError::Transport(msg.to_string());
+            dispatcher.fail_all_pending_requests(err.clone());
+            let got = received.lock().unwrap().clone().expect("handler called");
+            assert_eq!(got, err);
+            assert!(got.to_string().contains(should_contain));
+        }
+    }
+
+    #[test]
+    fn dispatcher_fail_all_clears_prebuffering_and_queue() {
+        let mut dispatcher = RpcDispatcher::new();
+        let req = crate::rpc::RpcRequest {
+            rpc_method_id: 99,
+            rpc_param_bytes: Some(vec![1, 2, 3]),
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: false,
+        };
+        let _enc = dispatcher
+            .call(req, 1024, |_: &[u8]| {}, Some(Box::new(|_| {})), true)
+            .expect("call with prebuffer");
+        assert_eq!(
+            dispatcher
+                .rpc_respondable_session
+                .get_remaining_response_handlers(),
+            1
+        );
+        let mut tmp = RpcDispatcher::new();
+        let mut rpc_bytes = Vec::new();
+        let req2 = crate::rpc::RpcRequest {
+            rpc_method_id: 100,
+            rpc_param_bytes: Some(vec![4, 5, 6]),
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: false,
+        };
+        let mut enc2 = tmp
+            .call(
+                req2,
+                1024,
+                |b: &[u8]| rpc_bytes.extend_from_slice(b),
+                None::<Box<dyn FnMut(crate::rpc::rpc_internals::RpcStreamEvent) + Send>>,
+                false,
+            )
+            .expect("tmp call");
+        enc2.end_stream().expect("end");
+        let _ = dispatcher.read_bytes(&rpc_bytes).expect("read_bytes");
+        assert!(!dispatcher.rpc_request_queue.lock().unwrap().is_empty());
+        dispatcher.fail_all_pending_requests(FrameDecodeError::Transport("test".to_string()));
+        assert_eq!(
+            dispatcher
+                .rpc_respondable_session
+                .get_remaining_response_handlers(),
+            0
+        );
+        assert!(dispatcher.rpc_request_queue.lock().unwrap().is_empty());
     }
 }

--- a/core/src/rpc/rpc_internals/rpc_respondable_session.rs
+++ b/core/src/rpc/rpc_internals/rpc_respondable_session.rs
@@ -24,8 +24,8 @@ pub struct RpcRespondableSession<'a> {
     // TODO: Make these names less vague
     pub(crate) response_handlers: HashMap<u32, Box<dyn FnMut(RpcStreamEvent) + Send + 'a>>,
     catch_all_response_handler: Option<Box<dyn FnMut(RpcStreamEvent) + Send + 'a>>,
-    prebuffered_responses: HashMap<u32, Vec<u8>>, // Track buffered responses by request ID
-    prebuffering_flags: HashMap<u32, bool>, // Track whether pre-buffering is enabled for each request
+    pub(crate) prebuffered_responses: HashMap<u32, Vec<u8>>, // Track buffered responses by request ID
+    pub(crate) prebuffering_flags: HashMap<u32, bool>, // Track whether pre-buffering is enabled for each request
     /// Optional router that maps (method_id, request_id) to a per-request handler.
     /// When set, it is consulted on each `Header` event. If it returns a handler,
     /// the handler is registered for that stream, bypassing the catch-all accumulator.
@@ -178,7 +178,8 @@ impl<'a> RpcRespondableSession<'a> {
                                 cb(rpc_payload_event);
                                 cb(evt.clone());
 
-                                self.prebuffered_responses.remove(&rpc_id); // Clear the buffer after calling
+                                self.prebuffered_responses.remove(&rpc_id);
+                                self.prebuffering_flags.remove(&rpc_id);
                             }
                         }
                         _ => {
@@ -195,6 +196,8 @@ impl<'a> RpcRespondableSession<'a> {
                     RpcStreamEvent::End { .. } | RpcStreamEvent::Error { .. }
                 ) {
                     self.response_handlers.remove(&rpc_id);
+                    self.prebuffering_flags.remove(&rpc_id);
+                    self.prebuffered_responses.remove(&rpc_id);
                 }
             }
 
@@ -210,5 +213,148 @@ impl<'a> RpcRespondableSession<'a> {
 
     pub fn get_remaining_response_handlers(&self) -> usize {
         self.response_handlers.len()
+    }
+
+    pub(crate) fn clear_all_prebuffering(&mut self) {
+        self.prebuffering_flags.clear();
+        self.prebuffered_responses.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rpc::rpc_internals::{RpcHeader, RpcMessageType, RpcStreamEvent};
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn prebuffering_flags_cleared_on_end() {
+        // Drive the actual state machine: client -> server -> client roundtrip with prebuffering=true
+        let client = Arc::new(Mutex::new(RpcRespondableSession::new(
+            crate::utils::IdSpace::Client,
+        )));
+        let server = Arc::new(Mutex::new(RpcRespondableSession::new(
+            crate::utils::IdSpace::Server,
+        )));
+
+        let mut server_inbox = Vec::new();
+        let client_inbox = Arc::new(Mutex::new(Vec::new()));
+
+        let call_header = RpcHeader {
+            rpc_msg_type: RpcMessageType::Call,
+            rpc_request_id: 1,
+            rpc_method_id: 42,
+            rpc_metadata_bytes: vec![],
+        };
+
+        // Server will reply with a single chunk and End
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        {
+            let pending_clone = Arc::clone(&pending);
+            server
+                .lock()
+                .unwrap()
+                .set_catch_all_response_handler(move |evt| {
+                    if let RpcStreamEvent::End { rpc_request_id, .. } = evt {
+                        let reply_header = RpcHeader {
+                            rpc_msg_type: RpcMessageType::Response,
+                            rpc_request_id,
+                            rpc_method_id: 42,
+                            rpc_metadata_bytes: vec![],
+                        };
+                        pending_clone.lock().unwrap().push(reply_header);
+                    }
+                });
+        }
+
+        let mut client_enc = client
+            .lock()
+            .unwrap()
+            .init_respondable_request(
+                call_header,
+                1024,
+                |bytes| server_inbox.push(bytes.to_vec()),
+                Some(Box::new(|_| {})),
+                true,
+            )
+            .expect("init");
+        client_enc.write_bytes(b"ping").unwrap();
+        client_enc.flush().unwrap();
+        client_enc.end_stream().unwrap();
+
+        for chunk in &server_inbox {
+            server.lock().unwrap().read_bytes(chunk).unwrap();
+        }
+        // Server has processed the Call and queued a reply header
+        assert_eq!(client.lock().unwrap().prebuffering_flags.len(), 1);
+        // Now create the actual reply bytes from the pending header and feed them to the client
+        for reply_header in pending.lock().unwrap().drain(..) {
+            let mut enc = server
+                .lock()
+                .unwrap()
+                .start_reply_stream(reply_header, 1024, |bytes| {
+                    client_inbox.lock().unwrap().push(bytes.to_vec())
+                })
+                .expect("server reply");
+            enc.write_bytes(b"hello").unwrap();
+            enc.flush().unwrap();
+            enc.end_stream().unwrap();
+        }
+        for chunk in client_inbox.lock().unwrap().iter() {
+            client.lock().unwrap().read_bytes(chunk).unwrap();
+        }
+        // After processing End, the prebuffering maps must be automatically cleared
+        let guard = client.lock().unwrap();
+        assert!(
+            guard.prebuffering_flags.is_empty(),
+            "prebuffering_flags should be cleared after End"
+        );
+        assert!(
+            guard.prebuffered_responses.is_empty(),
+            "prebuffered_responses should be cleared after End"
+        );
+        assert_eq!(guard.get_remaining_response_handlers(), 0);
+    }
+
+    #[test]
+    fn prebuffering_flags_cleared_on_error() {
+        // Verify that an Error event (e.g., transport failure) clears the
+        // prebuffering state via the actual state machine, not just the helper.
+        // We use RpcDispatcher's fail_all path which synthesizes an Error event
+        // for the pending request and should clear both maps.
+        use crate::rpc::RpcDispatcher;
+        use crate::rpc::RpcRequest;
+
+        let mut dispatcher = RpcDispatcher::new();
+        let req = RpcRequest {
+            rpc_method_id: 43,
+            rpc_param_bytes: None,
+            rpc_prebuffered_payload_bytes: None,
+            is_finalized: false,
+        };
+        let _enc = dispatcher
+            .call(req, 1024, |_: &[u8]| {}, Some(Box::new(|_| {})), true)
+            .expect("init");
+        assert_eq!(
+            dispatcher.rpc_respondable_session.prebuffering_flags.len(),
+            1
+        );
+        dispatcher.fail_all_pending_requests(crate::frame::FrameDecodeError::Transport(
+            "test".to_string(),
+        ));
+        assert!(
+            dispatcher
+                .rpc_respondable_session
+                .prebuffering_flags
+                .is_empty(),
+            "prebuffering_flags should be cleared after Error via fail_all"
+        );
+        assert!(
+            dispatcher
+                .rpc_respondable_session
+                .prebuffered_responses
+                .is_empty(),
+            "prebuffered_responses should be cleared after Error via fail_all"
+        );
     }
 }

--- a/extensions/muxio-tokio-rpc-ipc-client/src/rpc_ipc_client.rs
+++ b/extensions/muxio-tokio-rpc-ipc-client/src/rpc_ipc_client.rs
@@ -16,6 +16,12 @@ use tokio::{
 };
 use tracing::{self, instrument};
 
+/// Warn threshold for the unbounded client write queue (see Phase 3.5:
+/// backpressure is intentionally deferred, but depth is now visible).
+const WRITE_QUEUE_WARN_THRESHOLD: usize = 1024;
+static CLIENT_PENDING_WRITES: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
 type RpcTransportStateChangeHandler =
     Arc<StdMutex<Option<Box<dyn Fn(RpcTransportState) + Send + Sync>>>>;
 
@@ -26,6 +32,7 @@ pub struct RpcIpcClient {
     state_change_handler: RpcTransportStateChangeHandler,
     is_connected: Arc<AtomicBool>,
     task_handles: Vec<JoinHandle<()>>,
+    disconnect_error: Arc<StdMutex<Option<String>>>,
 }
 
 impl fmt::Debug for RpcIpcClient {
@@ -69,8 +76,18 @@ impl RpcIpcClient {
         {
             handler(RpcTransportState::Disconnected);
         }
+        let err = {
+            let guard = self
+                .disconnect_error
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            match guard.clone() {
+                Some(msg) => FrameDecodeError::Transport(msg),
+                None => FrameDecodeError::ReadAfterCancel,
+            }
+        };
         let mut dispatcher = self.dispatcher.lock().await;
-        dispatcher.fail_all_pending_requests(FrameDecodeError::ReadAfterCancel);
+        dispatcher.fail_all_pending_requests(err);
     }
 
     #[instrument]
@@ -90,7 +107,16 @@ impl RpcIpcClient {
                 let w = write_half.clone();
                 async move {
                     use tokio::io::AsyncWriteExt;
-                    w.lock().await.write_all(&msg).await.map_err(|_| ())
+                    let res = w.lock().await.write_all(&msg).await.map_err(|_| ());
+                    // Decrement pending counter after the frame is flushed or dropped,
+                    // guarding against underflow if the counter was already zero
+                    // (e.g. after a failed send that already undid its increment).
+                    let _ = CLIENT_PENDING_WRITES.fetch_update(
+                        Ordering::Relaxed,
+                        Ordering::Relaxed,
+                        |v| if v == 0 { None } else { Some(v - 1) },
+                    );
+                    res
                 }
             });
 
@@ -100,18 +126,37 @@ impl RpcIpcClient {
             let is_connected = Arc::new(AtomicBool::new(true));
             let dispatcher = Arc::new(TokioMutex::new(RpcDispatcher::new()));
             let endpoint = Arc::new(RpcServiceEndpoint::new());
+            let disconnect_error = Arc::new(StdMutex::new(None::<String>));
             let mut task_handles = Vec::new();
 
             task_handles.push(send_handle);
 
             let weak_for_read = weak_client.clone();
+            let disconnect_error_for_read = disconnect_error.clone();
             let read_stream = futures_util::stream::unfold(
                 (read_half, vec![0u8; 64 * 1024]),
-                |(mut r, mut buf)| async {
-                    let n = r.read(&mut buf).await.ok()?;
-                    if n == 0 {
-                        None
-                    } else {
+                move |(mut r, mut buf)| {
+                    let disconnect_error = disconnect_error_for_read.clone();
+                    async move {
+                        let n = match r.read(&mut buf).await {
+                            Ok(0) => {
+                                if let Ok(mut guard) = disconnect_error.lock()
+                                    && guard.is_none()
+                                {
+                                    *guard = Some("unexpected EOF (connection closed)".to_string());
+                                }
+                                tracing::debug!("RPC-IPC client read EOF");
+                                return None;
+                            }
+                            Ok(n) => n,
+                            Err(e) => {
+                                tracing::warn!(error = ?e, "RPC-IPC client read failed");
+                                if let Ok(mut guard) = disconnect_error.lock() {
+                                    *guard = Some(e.to_string());
+                                }
+                                return None;
+                            }
+                        };
                         Some((bytes::Bytes::copy_from_slice(&buf[..n]), (r, buf)))
                     }
                 },
@@ -134,6 +179,7 @@ impl RpcIpcClient {
                 state_change_handler,
                 is_connected,
                 task_handles,
+                disconnect_error,
             }
         });
 
@@ -179,16 +225,35 @@ impl RpcServiceCallerInterface for RpcIpcClient {
                     return;
                 }
                 let chunk_len = chunk.len();
+                let pending = CLIENT_PENDING_WRITES
+                    .fetch_add(1, Ordering::Relaxed)
+                    .wrapping_add(1);
+                if pending > WRITE_QUEUE_WARN_THRESHOLD {
+                    tracing::warn!(
+                        pending_writes = pending,
+                        threshold = WRITE_QUEUE_WARN_THRESHOLD,
+                        "Client write queue depth exceeded threshold"
+                    );
+                }
                 let send_result = tx.send(chunk);
                 match send_result {
                     Ok(_) => {
                         tracing::debug!("Emitted binary chunk ({} bytes) via mpsc.", chunk_len)
                     }
-                    Err(e) => tracing::debug!(
-                        "Failed to send binary chunk ({} bytes) via mpsc: {}",
-                        chunk_len,
-                        e
-                    ),
+                    Err(e) => {
+                        // Decrement on failure to keep counter roughly accurate,
+                        // guarding against underflow.
+                        let _ = CLIENT_PENDING_WRITES.fetch_update(
+                            Ordering::Relaxed,
+                            Ordering::Relaxed,
+                            |v| if v == 0 { None } else { Some(v - 1) },
+                        );
+                        tracing::debug!(
+                            "Failed to send binary chunk ({} bytes) via mpsc: {}",
+                            chunk_len,
+                            e
+                        )
+                    }
                 }
             }
         })

--- a/extensions/muxio-tokio-rpc-ipc-server/src/rpc_ipc_server.rs
+++ b/extensions/muxio-tokio-rpc-ipc-server/src/rpc_ipc_server.rs
@@ -13,6 +13,11 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::io::AsyncReadExt;
 use tokio::sync::{Mutex, mpsc};
 
+/// Warn threshold for the unbounded server write queue (minimal visibility,
+/// full backpressure deferred).
+#[allow(dead_code)]
+const SERVER_WRITE_QUEUE_WARN_THRESHOLD: usize = 1024;
+
 static NEXT_CONN_ID: AtomicUsize = AtomicUsize::new(1);
 
 /// Represents events that occur on the `RpcIpcServer`.
@@ -122,12 +127,17 @@ impl RpcIpcServer {
 
         let context_for_reader = context.clone();
         let self_for_reader = self.clone();
+        let server_disconnect_error = std::sync::Arc::new(std::sync::Mutex::new(None::<String>));
+        let server_disconnect_error_for_reader = server_disconnect_error.clone();
         let reader_handle = tokio::spawn(async move {
             let mut buf = vec![0u8; 64 * 1024];
             loop {
                 match read_half.read(&mut buf).await {
                     Ok(0) => {
                         tracing::info!("RPC-IPC client {} disconnected (EOF).", peer_label);
+                        if let Ok(mut guard) = server_disconnect_error_for_reader.lock() {
+                            *guard = Some("unexpected EOF (client closed)".to_string());
+                        }
                         break;
                     }
                     Ok(n) => {
@@ -168,20 +178,48 @@ impl RpcIpcServer {
                     }
                     Err(e) => {
                         tracing::error!("RPC-IPC server: read error from {}: {:?}", peer_label, e);
+                        if let Ok(mut guard) = server_disconnect_error_for_reader.lock() {
+                            *guard = Some(e.to_string());
+                        }
                         break;
                     }
                 }
             }
         });
 
+        let mut writer_handle = writer_handle;
+        let mut reader_handle = reader_handle;
         tokio::select! {
-            _ = writer_handle => {},
-            _ = reader_handle => {},
+            res = &mut writer_handle => {
+                if let Err(e) = res
+                    && e.is_panic()
+                {
+                    tracing::error!("RPC-IPC server: writer task panicked for client {conn_id}: {e:?}");
+                }
+                reader_handle.abort();
+            },
+            res = &mut reader_handle => {
+                if let Err(e) = res
+                    && e.is_panic()
+                {
+                    tracing::error!("RPC-IPC server: reader task panicked for client {conn_id}: {e:?}");
+                }
+                writer_handle.abort();
+            },
         }
 
         is_connected.store(false, Ordering::SeqCst);
+        let err = {
+            let guard = server_disconnect_error
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            match guard.clone() {
+                Some(msg) => FrameDecodeError::Transport(msg),
+                None => FrameDecodeError::ReadAfterCancel,
+            }
+        };
         let mut dg = context.dispatcher.lock().await;
-        dg.fail_all_pending_requests(FrameDecodeError::ReadAfterCancel);
+        dg.fail_all_pending_requests(err);
         if let Some(tx_event) = &self.event_tx {
             let _ = tx_event.send(RpcIpcServerEvent::ClientDisconnected(conn_id));
         }


### PR DESCRIPTION
### Added

- **Frame `Transport` decode error variant (`muxio-core`):** new `FrameDecodeError::Transport(String)` carries the real `std::io::Error` display for transport failures so `fail_all_pending_requests` can surface `ConnectionReset`, `BrokenPipe`, or `UnexpectedEof` instead of a static `ReadAfterCancel`.

### Fixed

- **IPC client/server transport error propagation:** client read loop now distinguishes `Ok(0)` (synthesized unexpected EOF) from `Err(e)` (logs `warn!` and stores the error) instead of swallowing via `ok()?`, server read loop does the same, and both shutdown paths thread the concrete error into `fail_all_pending_requests` so pending oneshots receive the root cause.
- **Prebuffering flags leak:** `prebuffering_flags` entries were inserted per outbound call and never removed; now cleared on `End`/`Error` and via `clear_all_prebuffering` in `fail_all`.
- **Inbound request queue leak:** `rpc_request_queue` entries for errored or non-finalized streams lingered; `fail_all_pending_requests` now drains the queue so a dead connection does not leak state.

### Changed

- **Panic-aware server per-connection tasks:** `handle_connection` now retains `writer_handle` and `reader_handle`, checks `JoinError::is_panic()` and logs with `conn_id` instead of silently discarding via `select!` drop, and aborts the peer task.
- **Write queue depth visibility:** defined `WRITE_QUEUE_WARN_THRESHOLD` and `SERVER_WRITE_QUEUE_WARN_THRESHOLD` with a client-side atomic counter and `warn!` when the threshold is exceeded; full backpressure redesign remains deferred.
- **Dependency bumps (`Cargo.lock`):** `futures 0.3.33 → 0.3.34` (#105), `async-trait 0.1.91 → 0.1.92` (#104) — patch bumps via Dependabot (`futures 0.3.34` upgrades `futures-channel`, `futures-core`, `futures-executor`, `futures-io`, `futures-sink`, `futures-task`, `futures-util`, `futures-macro` with `syn 2.0.118 → 3.0.3`).
